### PR TITLE
fix: resolve infinite redirect loop in login page

### DIFF
--- a/examples/privy-nextjs-notus-api/src/app/login/login-page.tsx
+++ b/examples/privy-nextjs-notus-api/src/app/login/login-page.tsx
@@ -14,11 +14,10 @@ import {
 	CardHeader,
 	CardTitle,
 } from "@notus-api-examples/ui/components/card";
-import { redirect } from "next/navigation";
 
 export default function LoginPage() {
 	const { initOAuth, loading } = useLoginWithOAuth();
-	const { ready, authenticated } = usePrivy();
+	const { ready } = usePrivy();
 
 	if (loading || !ready)
 		return (
@@ -26,10 +25,6 @@ export default function LoginPage() {
 				<div className="animate-pulse">Loading...</div>
 			</div>
 		);
-
-	if (authenticated) {
-		redirect("/");
-	}
 
 	return (
 		<div className="flex min-h-screen items-center justify-center bg-background px-4 py-12 sm:px-6 lg:px-8">


### PR DESCRIPTION
## Bug Fix
     
Resolves infinite redirect loop between `/` and `/login` pages.

## Problem
- Client-side redirect in `LoginPage` component was conflicting with server-side redirects
- This caused an infinite loop when users tried to access the application

## Solution
- Removed unnecessary client-side redirect and `authenticated` check
- Kept only server-side redirect logic to prevent conflicts
- Maintained proper authentication flow

## Testing
- [x] Login flow works correctly
- [x] No more infinite redirects
- [x] Proper redirection after authentication